### PR TITLE
duplicate pointer variable

### DIFF
--- a/currency/data/rates.go
+++ b/currency/data/rates.go
@@ -91,7 +91,7 @@ func (e *ExchangeRates) getRates() error {
 	}
 	defer resp.Body.Close()
 
-	md := &Cubes{}
+	md := Cubes{}
 	xml.NewDecoder(resp.Body).Decode(&md)
 
 	for _, c := range md.CubeData {


### PR DESCRIPTION
inline 94 you were creating a pointer variable as `cube`, and in line 95, also you were trying to pass the address of `md`, (pointer to pointer?) to `Decode`,
so as a best practice I think creates a variable and passes the reference of it, is cleaner and not redundant.
I didn't do scape analyses, but also you didn't need the  'md' variable to scape to `heap`